### PR TITLE
Fix distance example output

### DIFF
--- a/CamJam Edukit 3 - GPIO Zero/Code/6-distance.py
+++ b/CamJam Edukit 3 - GPIO Zero/Code/6-distance.py
@@ -15,7 +15,7 @@ print("Ultrasonic Measurement")
 try:
     # Repeat the next indented block forever
     while True:
-        print("Distance: %.1f cm" % sensor.distance * 100)
+        print("Distance: %.1f cm" % (sensor.distance * 100))
         time.sleep(0.5)
 
 # If you press CTRL+C, cleanup and stop


### PR DESCRIPTION
To fix https://github.com/CamJam-EduKit/EduKit3/issues/15
Instead of converting m to cm, the code was printing m output 100 times.